### PR TITLE
Clarify all remaining contribution rules

### DIFF
--- a/src/app/dashboard/simulator/[planId]/components/inputs/contribution-limit-tooltip.tsx
+++ b/src/app/dashboard/simulator/[planId]/components/inputs/contribution-limit-tooltip.tsx
@@ -1,0 +1,31 @@
+import { InfoIcon } from 'lucide-react';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { formatCompactCurrency } from '@/lib/utils/number-formatters';
+
+interface ContributionLimitTooltipProps {
+  annualLimit: number | null;
+}
+
+/**
+ * Explains the account-level cap behind an "All Remaining" contribution rule.
+ */
+export default function ContributionLimitTooltip({ annualLimit }: ContributionLimitTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger className="text-muted-foreground">
+        <InfoIcon className="size-4 fill-white dark:fill-stone-950" />
+      </TooltipTrigger>
+      <TooltipContent>
+        {annualLimit !== null && Number.isFinite(annualLimit) ? (
+          <p>
+            Uses the current annual account limit of {formatCompactCurrency(annualLimit, 0)} before earlier rules, income caps, employer
+            match, and max balance are applied.
+          </p>
+        ) : (
+          <p>This account type has no annual contribution limit before income caps or max balance are applied.</p>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/app/dashboard/simulator/[planId]/components/inputs/dialogs/contribution-rule-dialog.tsx
+++ b/src/app/dashboard/simulator/[planId]/components/inputs/dialogs/contribution-rule-dialog.tsx
@@ -20,9 +20,7 @@ import {
   supportsIncomeAllocation,
   supportsEmployerMatch,
   supportsMegaBackdoorRoth,
-  getAccountTypeLimitKey,
-  getAnnualContributionLimit,
-  getAnnualSection415cLimit,
+  getAnnualContributionLimitForAccount,
 } from '@/lib/schemas/inputs/contribution-form-schema';
 import { accountTypeForDisplay } from '@/lib/schemas/inputs/account-form-schema';
 import { calculateAge } from '@/lib/schemas/inputs/timeline-form-schema';
@@ -36,6 +34,7 @@ import { formatCompactCurrency, getCurrencySymbol, formatCurrencyPlaceholder } f
 import { useSelectedPlanId } from '@/hooks/use-selected-plan-id';
 import { getErrorMessages } from '@/lib/utils/form-utils';
 import { Divider } from '@/components/catalyst/divider';
+import ContributionLimitTooltip from '../contribution-limit-tooltip';
 
 interface ContributionRuleDialogProps {
   onClose: () => void;
@@ -110,9 +109,7 @@ export default function ContributionRuleDialog({
   const timeline = useTimelineData();
   const currentAge = timeline ? calculateAge(timeline.birthMonth, timeline.birthYear) : 18;
   const selectedAccountAnnualContributionLimit = selectedAccount
-    ? enableMegaBackdoorRoth
-      ? getAnnualSection415cLimit(currentAge)
-      : getAnnualContributionLimit(getAccountTypeLimitKey(selectedAccount.type), currentAge)
+    ? getAnnualContributionLimitForAccount(selectedAccount.type, currentAge, { enableMegaBackdoorRoth })
     : null;
 
   const { data: incomes } = useIncomesData();
@@ -203,7 +200,10 @@ export default function ContributionRuleDialog({
               )}
               <div className="grid grid-cols-2 gap-x-4 gap-y-2">
                 <Field className={getContributionTypeColSpan()}>
-                  <Label htmlFor="contributionType">Type</Label>
+                  <Label htmlFor="contributionType" className="flex items-center gap-1.5">
+                    Type
+                    {contributionType === 'unlimited' && <ContributionLimitTooltip annualLimit={selectedAccountAnnualContributionLimit} />}
+                  </Label>
                   <Select
                     {...register('contributionType')}
                     id="contributionType"
@@ -212,7 +212,7 @@ export default function ContributionRuleDialog({
                   >
                     <option value="dollarAmount">Dollar Amount</option>
                     <option value="percentRemaining">% Remaining</option>
-                    <option value="unlimited">Unlimited</option>
+                    <option value="unlimited">All Remaining</option>
                   </Select>
                   {errors.contributionType && <ErrorMessage>{errors.contributionType?.message}</ErrorMessage>}
                 </Field>

--- a/src/app/dashboard/simulator/[planId]/components/inputs/sections/contribution-order-section.tsx
+++ b/src/app/dashboard/simulator/[planId]/components/inputs/sections/contribution-order-section.tsx
@@ -20,7 +20,7 @@ import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSo
 import { restrictToParentElement } from '@dnd-kit/modifiers';
 import { Field as HeadlessField } from '@headlessui/react';
 
-import { useContributionRulesData, useBaseContributionRuleData, useAccountsData } from '@/hooks/use-convex-data';
+import { useContributionRulesData, useBaseContributionRuleData, useAccountsData, useTimelineData } from '@/hooks/use-convex-data';
 import { contributionToConvex, baseContributionToConvex } from '@/lib/utils/data-transformers';
 import DisclosureSection from '@/components/ui/disclosure-section';
 import { Dialog } from '@/components/catalyst/dialog';
@@ -30,9 +30,14 @@ import type { DisclosureState } from '@/lib/types/disclosure-state';
 import { Divider } from '@/components/catalyst/divider';
 import { Select } from '@/components/catalyst/select';
 import { Label } from '@/components/catalyst/fieldset';
-import type { ContributionInputs, BaseContributionInputs } from '@/lib/schemas/inputs/contribution-form-schema';
+import {
+  type ContributionInputs,
+  type BaseContributionInputs,
+  getAnnualContributionLimitForAccount,
+} from '@/lib/schemas/inputs/contribution-form-schema';
 import { accountTypeForDisplay, type AccountInputs, taxCategoryFromAccountType } from '@/lib/schemas/inputs/account-form-schema';
 import type { TaxCategory } from '@/lib/calc/asset';
+import { calculateAge } from '@/lib/schemas/inputs/timeline-form-schema';
 import { useSelectedPlanId } from '@/hooks/use-selected-plan-id';
 import DeleteDataItemAlert from '@/components/ui/delete-data-item-alert';
 import DataListEmptyStateButton from '@/components/ui/data-list-empty-state-button';
@@ -42,11 +47,18 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import ContributionRuleDialog from '../dialogs/contribution-rule-dialog';
 import SortableContributionItem from '../sortable-contribution-item';
 import ContributionItem from '../contribution-item';
+import ContributionLimitTooltip from '../contribution-limit-tooltip';
 
-function getContributionRuleDesc(accounts: Record<string, AccountInputs>, contributionInputs: ContributionInputs) {
-  const accountType = accountTypeForDisplay(accounts[contributionInputs.accountId]?.type);
+function getContributionRuleDesc(accounts: Record<string, AccountInputs>, contributionInputs: ContributionInputs, currentAge: number) {
+  const account = accounts[contributionInputs.accountId];
+  const accountType = accountTypeForDisplay(account?.type);
+  const annualLimit = account
+    ? getAnnualContributionLimitForAccount(account.type, currentAge, {
+        enableMegaBackdoorRoth: contributionInputs.enableMegaBackdoorRoth,
+      })
+    : null;
 
-  let description: string;
+  let description: React.ReactNode;
   switch (contributionInputs.contributionType) {
     case 'dollarAmount':
       description = `${formatCompactCurrency(contributionInputs.dollarAmount, 2)} per year`;
@@ -55,7 +67,12 @@ function getContributionRuleDesc(accounts: Record<string, AccountInputs>, contri
       description = `${contributionInputs.percentRemaining}% remaining`;
       break;
     case 'unlimited':
-      description = 'Unlimited';
+      description = (
+        <span className="inline-flex items-center gap-1">
+          All remaining up to limits
+          <ContributionLimitTooltip annualLimit={annualLimit} />
+        </span>
+      );
       break;
   }
 
@@ -88,6 +105,8 @@ export default function ContributionOrderSection(props: ContributionOrderSection
   const [activeId, setActiveId] = useState<string | null>(null);
 
   const { data: accounts, isLoading: isLoadingAccounts } = useAccountsData();
+  const timeline = useTimelineData();
+  const currentAge = timeline ? calculateAge(timeline.birthMonth, timeline.birthYear) : 18;
   const { data: contributionRules, isLoading: isLoadingContributionRules } = useContributionRulesData();
   const contributionRulesValues = Object.values(contributionRules);
 
@@ -247,7 +266,7 @@ export default function ContributionOrderSection(props: ContributionOrderSection
                         id={id}
                         index={index}
                         name={`To ${accounts[contributionRule.accountId]?.name || 'Unknown'}`}
-                        desc={getContributionRuleDesc(accounts, { id, ...contributionRule })}
+                        desc={getContributionRuleDesc(accounts, { id, ...contributionRule }, currentAge)}
                         leftAddOn={String(index + 1)}
                         disabled={contributionRule.disabled}
                         onDropdownClickEdit={() => handleDropdownClickEdit({ id, ...contributionRule })}
@@ -267,7 +286,7 @@ export default function ContributionOrderSection(props: ContributionOrderSection
                       id={activeId}
                       index={activeIndex}
                       name={`To ${accounts[activeContributionRule.accountId]?.name || 'Unknown'}`}
-                      desc={getContributionRuleDesc(accounts, activeContributionRule)}
+                      desc={getContributionRuleDesc(accounts, activeContributionRule, currentAge)}
                       leftAddOn={String(activeIndex + 1)}
                       disabled={activeContributionRule.disabled}
                       onDropdownClickEdit={() => handleDropdownClickEdit(activeContributionRule)}

--- a/src/lib/schemas/inputs/contribution-form-schema.test.ts
+++ b/src/lib/schemas/inputs/contribution-form-schema.test.ts
@@ -3,6 +3,7 @@ import {
   contributionFormSchema,
   getAccountTypeLimitKey,
   getAnnualContributionLimit,
+  getAnnualContributionLimitForAccount,
   getAnnualSection415cLimit,
   supportsMaxBalance,
   supportsIncomeAllocation,
@@ -109,6 +110,23 @@ describe('getAnnualSection415cLimit', () => {
 
   it('should return catch-up limit for age 64+', () => {
     expect(getAnnualSection415cLimit(64)).toBe(80000);
+  });
+});
+
+describe('getAnnualContributionLimitForAccount', () => {
+  it('should return the standard annual limit for the account type', () => {
+    expect(getAnnualContributionLimitForAccount('401k', 30)).toBe(24500);
+    expect(getAnnualContributionLimitForAccount('rothIra', 50)).toBe(8600);
+    expect(getAnnualContributionLimitForAccount('hsa', 55)).toBe(5400);
+  });
+
+  it('should use the Section 415(c) limit for mega backdoor Roth rules on supported accounts', () => {
+    expect(getAnnualContributionLimitForAccount('roth401k', 30, { enableMegaBackdoorRoth: true })).toBe(72000);
+    expect(getAnnualContributionLimitForAccount('roth403b', 50, { enableMegaBackdoorRoth: true })).toBe(80000);
+  });
+
+  it('should ignore mega backdoor Roth for unsupported accounts', () => {
+    expect(getAnnualContributionLimitForAccount('rothIra', 30, { enableMegaBackdoorRoth: true })).toBe(7500);
   });
 });
 

--- a/src/lib/schemas/inputs/contribution-form-schema.ts
+++ b/src/lib/schemas/inputs/contribution-form-schema.ts
@@ -102,6 +102,22 @@ export const getAnnualSection415cLimit = (age: number): number => {
   return 72000;
 };
 
+/**
+ * Returns the annual contribution cap used for an account before rule-order,
+ * income-source, employer-match, or max-balance constraints are applied.
+ */
+export const getAnnualContributionLimitForAccount = (
+  accountType: AccountInputs['type'],
+  age: number,
+  options?: { enableMegaBackdoorRoth?: boolean }
+): number => {
+  if (options?.enableMegaBackdoorRoth && supportsMegaBackdoorRoth(accountType)) {
+    return getAnnualSection415cLimit(age);
+  }
+
+  return getAnnualContributionLimit(getAccountTypeLimitKey(accountType), age);
+};
+
 export const supportsMaxBalance = (type: AccountInputs['type']): boolean => {
   switch (type) {
     case 'savings':


### PR DESCRIPTION
## Summary

- Renames the contribution rule type from "Unlimited" to "All Remaining" in the edit dialog
- Shows an info tooltip for All Remaining rules in the dialog and contribution-order list
- Shares the annual account-limit calculation between the dialog and list copy

## Test plan

- [x] npm run test:once -- src/lib/schemas/inputs/contribution-form-schema.test.ts
- [x] npm run typecheck
- [x] npm run lint